### PR TITLE
Fixed bug in nodejs 0.10

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,9 +44,10 @@ Zip.prototype.add = function(paths, opt_callback, opt_basepath) {
 
     var config = instance.config,
         filepath = paths.pop(),
-        relative = path.join(config.root, opt_basepath, path.relative(opt_basepath, filepath));
+        relative;
 
     if (filepath) {
+        relative = path.join(config.root, opt_basepath, path.relative(opt_basepath, filepath));
         fs.stat(filepath, function(err, stat) {
             if (!stat) {
                 console.log('File ' + filepath + ' not found.');


### PR DESCRIPTION
In the new version of nodejs, arguments to path.relative() cannot be undefined.  I made a tiny two-line patch that fixes a bug I was encountering, thanks to this change in node's behavior.

Great library, by the way, thanks!
